### PR TITLE
Privateサブネットを削除

### DIFF
--- a/.github/workflows/aws_cdk_deploy.yaml
+++ b/.github/workflows/aws_cdk_deploy.yaml
@@ -3,7 +3,7 @@ name: AWS CDK deploy
 on:
   push:
     branches:
-    - main
+      - main
 
 jobs:
   test:
@@ -16,7 +16,7 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v2
         with:
-          node-version: '18.14'
+          node-version: "18.14"
       - name: setup dependencies
         run: npm ci
       - name: build
@@ -26,12 +26,12 @@ jobs:
       - name: CDK diff check
         run: npx cdk diff --context targetEnvironment=production
         env:
-          AWS_DEFAULT_REGION: 'ap-northeast-1'
+          AWS_DEFAULT_REGION: "ap-northeast-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: CDK deploy
-        run: npx cdk deploy --context targetEnvironment=production --outputs-file ./cdk-outputs.json
+        run: npx cdk deploy --context targetEnvironment=production --outputs-file ./cdk-outputs.json --all
         env:
-          AWS_DEFAULT_REGION: 'ap-northeast-1'
+          AWS_DEFAULT_REGION: "ap-northeast-1"
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/CDK/lib/vpcStack.ts
+++ b/CDK/lib/vpcStack.ts
@@ -21,12 +21,12 @@ export class VPCStack extends cdk.Stack {
       subnetConfiguration: [
         {
           cidrMask: 24,
-          name: "ingress",
+          name: "public",
           subnetType: SubnetType.PUBLIC,
         },
         {
           cidrMask: 24,
-          name: "rds",
+          name: "private",
           subnetType: SubnetType.PRIVATE_ISOLATED,
         },
       ],

--- a/CDK/lib/vpcStack.ts
+++ b/CDK/lib/vpcStack.ts
@@ -1,5 +1,5 @@
 import * as cdk from "aws-cdk-lib";
-import { CfnEIP, CfnKeyPair, IpAddresses, Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnEIP, SubnetType, IpAddresses, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Construct } from "constructs";
 import { StackConfig } from "./stackConfig";
 import { vpcCidr } from "./vpcCidr";
@@ -18,6 +18,18 @@ export class VPCStack extends cdk.Stack {
 
     this.vpc = new Vpc(this, `vpc`, {
       ipAddresses: IpAddresses.cidr(vpcCidr[stackConfig.targetEnvironment]),
+      subnetConfiguration: [
+        {
+          cidrMask: 24,
+          name: "ingress",
+          subnetType: SubnetType.PUBLIC,
+        },
+        {
+          cidrMask: 24,
+          name: "rds",
+          subnetType: SubnetType.PRIVATE_ISOLATED,
+        },
+      ],
       maxAzs: 2,
     });
 

--- a/CDK/lib/vpnStack.ts
+++ b/CDK/lib/vpnStack.ts
@@ -66,7 +66,7 @@ export class VPNStack extends cdk.Stack {
         "/aws/service/ami-amazon-linux-latest/al2022-ami-kernel-5.15-x86_64"
       ),
       vpcSubnets: {
-        subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+        subnetType: SubnetType.PRIVATE_ISOLATED,
       },
       userData: userData,
       ssmSessionPermissions: true,


### PR DESCRIPTION
![スクリーンショット 2023-06-03 20 31 10](https://github.com/yuchiki/home-server-provisioning/assets/14884013/0c86692d-94df-4ef5-9466-51d4651d6451)


AWS料金がこの２ヶ月跳ね上がっている。調査したところNAT gateway 代だった

CDK のVPCモジュールはデフォルトで、 public, private_with_egress（外に出ていけるprivate=NAT があるprivate subnet), private_isolated の３subnetを作る。
今回は private_with_egress を削除した


- ネットワークの破壊・再設計はかなり問題だけど、まだ上にVPNくらいしか載っていないのでヨシ！

# 確認方法

https://github.com/yuchiki/home-server-provisioning/actions/runs/5164204485/jobs/9302955506

- このdiffをみると、NATゲートウェイが削除予定で、新しく作流ものリストに含まれていない