### PR TITLE
AWS CDKのバグにより、image名を明示的に指定

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "prettier.prettierPath": "./CDK/node_modules/prettier"
 }

--- a/CDK/lib/vpnStack.ts
+++ b/CDK/lib/vpnStack.ts
@@ -40,7 +40,7 @@ export class VPNStack extends cdk.Stack {
     );
 
     const vpnKeyPair = new CfnKeyPair(this, "KeyPair for VPN", {
-      keyName: "VPNKeyPair",
+      keyName: `${stackConfig.targetEnvironment}-VPNKeyPair`,
     });
     vpnKeyPair.applyRemovalPolicy(cdk.RemovalPolicy.DESTROY);
 
@@ -63,7 +63,7 @@ export class VPNStack extends cdk.Stack {
       vpc: vpc,
       instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.MICRO),
       machineImage: MachineImage.fromSsmParameter(
-        "/aws/service/ami-amazon-linux-latest/al2022-ami-kernel-5.15-x86_64"
+        "/aws/service/ami-amazon-linux-latest/al2022-ami-kernel-6.1-x86_64"
       ),
       vpcSubnets: {
         subnetType: SubnetType.PRIVATE_ISOLATED,


### PR DESCRIPTION
前回指定していたバージョンが使えなくなっていたのでバージョンを上げる

# 動作確認方法
devでデプロイが正常終了することを確かめた
![image](https://github.com/yuchiki/home-server-provisioning/assets/14884013/a532e7a9-4f57-444c-a99f-4c195df36b24)
