### PR TITLE
fix ami image name

### DIFF
--- a/CDK/lib/vpnStack.ts
+++ b/CDK/lib/vpnStack.ts
@@ -63,7 +63,7 @@ export class VPNStack extends cdk.Stack {
       vpc: vpc,
       instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.MICRO),
       machineImage: MachineImage.fromSsmParameter(
-        "/aws/service/ami-amazon-linux-latest/al2022-ami-kernel-6.1-x86_64"
+        "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64"
       ),
       vpcSubnets: {
         subnetType: SubnetType.PRIVATE_ISOLATED,


### PR DESCRIPTION
# 概要

AMIイメージ名は 2022- ... ではなく 2023-... であった

![image](https://github.com/yuchiki/home-server-provisioning/assets/14884013/9223759d-9217-499e-9d09-abfc7d951819)


以下は `make cdk-deploy-dev` が正常に走り切っているログ


```
 $ make cdk-deploy-dev             
make -C CDK  deploy-dev
make[1]: Entering directory '/workspaces/home-server-provisioning/CDK'
cdk deploy --outputs-file ./cdk-outputs.json --all

✨  Synthesis time: 3.42s

yuchiki-vpc-stack-development
yuchiki-vpn-stack-development:  start: Building dfe001650a1b0d626c6a029b91ef747024b846ddf1c08954a6115b8f6a3e9344:current_account-current_region
yuchiki-vpn-stack-development:  success: Built dfe001650a1b0d626c6a029b91ef747024b846ddf1c08954a6115b8f6a3e9344:current_account-current_region
yuchiki-vpc-stack-development: deploying... [1/2]

 ✅  yuchiki-vpc-stack-development (no changes)

✨  Deployment time: 0.33s

Outputs:
yuchiki-vpc-stack-development.ExportsOutputRefElasticIPforVPND0A0B574 = 3.114.125.84
yuchiki-vpc-stack-development.ExportsOutputRefvpcA2121C384D1B3CDE = vpc-0723da8670f579b82
yuchiki-vpc-stack-development.ExportsOutputRefvpcprivateSubnet1SubnetAE1393DC18E7B349 = subnet-09ee357c723cf42c7
yuchiki-vpc-stack-development.vpnElasticIP = 3.114.125.84
Stack ARN:
arn:aws:cloudformation:ap-northeast-1:714992848690:stack/yuchiki-vpc-stack-development/dcba88a0-1e3b-11ee-8c7b-0edc99796a73

✨  Total time: 3.75s

yuchiki-vpn-stack-development:  start: Publishing dfe001650a1b0d626c6a029b91ef747024b846ddf1c08954a6115b8f6a3e9344:current_account-current_region
yuchiki-vpn-stack-development:  success: Published dfe001650a1b0d626c6a029b91ef747024b846ddf1c08954a6115b8f6a3e9344:current_account-current_region
yuchiki-vpn-stack-development
This deployment will make potentially sensitive changes according to your current security approval level (--require-approval broadening).
Please confirm you intend to make the following modifications:

IAM Statement Changes
┌───┬─────────────────────────┬────────┬────────────────┬───────────────────────────┬───────────┐
│   │ Resource                │ Effect │ Action         │ Principal                 │ Condition │
├───┼─────────────────────────┼────────┼────────────────┼───────────────────────────┼───────────┤
│ + │ ${vpn/InstanceRole.Arn} │ Allow  │ sts:AssumeRole │ Service:ec2.amazonaws.com │           │
└───┴─────────────────────────┴────────┴────────────────┴───────────────────────────┴───────────┘
IAM Policy Changes
┌───┬─────────────────────┬────────────────────────────────────────────────────────────────────┐
│   │ Resource            │ Managed Policy ARN                                                 │
├───┼─────────────────────┼────────────────────────────────────────────────────────────────────┤
│ + │ ${vpn/InstanceRole} │ arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore │
└───┴─────────────────────┴────────────────────────────────────────────────────────────────────┘
Security Group Changes
┌───┬─────────────────────────────────────┬─────┬────────────┬─────────────────┐
│   │ Group                               │ Dir │ Protocol   │ Peer            │
├───┼─────────────────────────────────────┼─────┼────────────┼─────────────────┤
│ + │ ${VPNInstanceSecurityGroup.GroupId} │ Out │ Everything │ Everyone (IPv4) │
└───┴─────────────────────────────────────┴─────┴────────────┴─────────────────┘
(NOTE: There may be security-related changes not in this list. See https://github.com/aws/aws-cdk/issues/1299)

Do you wish to deploy these changes (y/n)? y
yuchiki-vpn-stack-development: deploying... [2/2]
yuchiki-vpn-stack-development: creating CloudFormation changeset...

 ✅  yuchiki-vpn-stack-development

✨  Deployment time: 225.44s

Outputs:
yuchiki-vpn-stack-development.GetSSHKeyCommand = aws ssm get-parameter --name /ec2/keypair/key-0a800c87d1cd934c6 --region ap-northeast-1 --with-decryption --query Parameter.Value --output text
yuchiki-vpn-stack-development.VPNInstanceSecurityGroupId = sg-0355133b706bce8cd
Stack ARN:
arn:aws:cloudformation:ap-northeast-1:714992848690:stack/yuchiki-vpn-stack-development/15738f70-1e3c-11ee-9d3a-06c764b75e41

✨  Total time: 228.86s


make[1]: Leaving directory '/workspaces/home-server-provisioning/CDK'
```