### PR TITLE
おうちDNS周りに関連した設定のTODOを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,43 @@
 # 概要
+
 自宅鯖設定のためのリポジトリ
 
 # 注意
 
-1. 一番最初に `make set-githook` を実行してください。秘匿情報を平文のままcommit したり pushしたりするのを防ぐためのスクリプトです。
-2. secrets.yamlを変更するために平文化した後は、必ずコミット・pushする前に暗号化してください。（githooksで平文のままのコミットを防ぐ仕組みは存在しています）
+1. 一番最初に `make set-githook` を実行してください。秘匿情報を平文のまま commit したり push したりするのを防ぐためのスクリプトです。
+2. secrets.yaml を変更するために平文化した後は、必ずコミット・push する前に暗号化してください。（githooks で平文のままのコミットを防ぐ仕組みは存在しています）
 
 # 開発
 
-vault-password.txt に vault keyを設置します。
-このkeyによって、 secrets.yamlの秘匿情報を閲覧、平文化、暗号化することができます。
+vault-password.txt に vault key を設置します。
+この key によって、 secrets.yaml の秘匿情報を閲覧、平文化、暗号化することができます。
 vault key は growi に記載されています
 
 # 前提条件
 
--  secrets.yamlに記載の通りの、ssh 権限を持った非rootユーザーが作成されていることが必要です。
--  ゆーちきAWS環境にアクセスできる状態にlocalのAWSCLI設定がなされている必要があります。
+- secrets.yaml に記載の通りの、ssh 権限を持った非 root ユーザーが作成されていることが必要です。
+- ゆーちき AWS 環境にアクセスできる状態に local の AWSCLI 設定がなされている必要があります。
 
 # 使用方法
 
 `make provision` をした後、ユーザーが作成されます。
-初期パスワードは ansible/vars/secrets.yamlの中です。
+初期パスワードは ansible/vars/secrets.yaml の中です。
 自分の好きなパスワードに変えてください。
 
 # 秘匿情報の編集
 
 `ansible-vault edit` コマンドを用いてください。
 
-
 # ロードマップ
 
 [roadmap](docs/roadmap.md)
+
+# ansible にまだ組み込めてないこと
+
+- k3s の入れ方
+  - `curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --disable=traefik" sh`
+  - この構成だと istio を使っているので traefik 抜きである必要がある
+- argoCD の導入
+- [internal-proxy](./internal-proxy/)の導入
+  - これで`sudo docker-compose up -d` すればいいはず
+  - 現在は`~/dns` で dns という名前で動いているので、それを一回消してから

--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ vault key は growi に記載されています
 - [internal-proxy](./internal-proxy/)の導入
   - これで`sudo docker-compose up -d` すればいいはず
   - 現在は`~/dns` で dns という名前で動いているので、それを一回消してから
+- ufw の操作

--- a/internal-proxy/docker-compose.yaml
+++ b/internal-proxy/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+  nginx:
+    image: tekn0ir/nginx-stream
+    ports:
+      - "53:53"
+      - "53:53/udp"
+      - "34197:34197/udp"
+    volumes:
+      - ./http.conf.d:/opt/nginx/http.conf.d
+      - ./stream.conf.d:/opt/nginx/stream.conf.d
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/internal-proxy/stream.conf.d/stream.conf
+++ b/internal-proxy/stream.conf.d/stream.conf
@@ -12,14 +12,14 @@ listen 53 udp;
 proxy_pass host.docker.internal:30053;
 }
 
-# factorio
+# factorio (この設定はうまく動かない？)
 server {
 listen 34197 udp;
 proxy_pass host.docker.internal:30893;
 }
 
 
-# factorio(rcon)
+# factorio(rcon) (この設定はうまく動かない？)
 server {
 listen 27015;
 proxy_pass host.docker.internal:30894;

--- a/internal-proxy/stream.conf.d/stream.conf
+++ b/internal-proxy/stream.conf.d/stream.conf
@@ -1,0 +1,26 @@
+error_log /opt/nginx/logs/stream_log info;
+
+# DNS(TCP)
+server {
+listen 53;
+proxy_pass host.docker.internal:30053;
+}
+
+# DNS(UDP)
+server {
+listen 53 udp;
+proxy_pass host.docker.internal:30053;
+}
+
+# factorio
+server {
+listen 34197 udp;
+proxy_pass host.docker.internal:30893;
+}
+
+
+# factorio(rcon)
+server {
+listen 27015;
+proxy_pass host.docker.internal:30894;
+}


### PR DESCRIPTION
見ての通り

# 現在の構成
DNSサーバーをk3s上で動かしているが、30053でnordPortで公開している。
これを、一般的な53 -> 30053の変換をするためにdocker-composeで動いた nginxで受けている。
この通信は家の中からのみ可能である（外からはAWSのALBで80, 443に限り受け付けており、自宅鯖の 8080に飛ばしている以外の経路がないため）